### PR TITLE
Batch messages on receiving instead of on command

### DIFF
--- a/src/main/java/ml/denisd3d/minecraft2discord/commands/DiscordCommandSource.java
+++ b/src/main/java/ml/denisd3d/minecraft2discord/commands/DiscordCommandSource.java
@@ -1,5 +1,7 @@
 package ml.denisd3d.minecraft2discord.commands;
 
+import ml.denisd3d.minecraft2discord.managers.ChannelManager;
+import ml.denisd3d.minecraft2discord.managers.MessageManager;
 import net.minecraft.command.ICommandSource;
 import net.minecraft.util.text.ITextComponent;
 import org.jetbrains.annotations.NotNull;
@@ -7,13 +9,15 @@ import org.jetbrains.annotations.NotNull;
 import java.util.UUID;
 
 public class DiscordCommandSource implements ICommandSource {
-
+    private Thread messageScheduler;
+    private long time;
     public static String answer = ""; // This is a hack to have only one string as result for the command. We need to clear it after each use and get the result by our self
 
     @Override
     public void sendMessage(ITextComponent component, UUID p_145747_2_)
     {
         answer += component.getString() + "\n";
+        scheduleMessage();
     }
 
     @Override
@@ -31,5 +35,24 @@ public class DiscordCommandSource implements ICommandSource {
         return true;
     }
 
-
+    private void scheduleMessage() {
+        time = System.currentTimeMillis();
+        if (messageScheduler == null || !messageScheduler.isAlive()) {
+            messageScheduler = new Thread(() -> {
+                while (true) {
+                    if (System.currentTimeMillis() - time > 100) {
+                        MessageManager.sendQuotesMessage(ChannelManager.getChatChannel(), answer);
+                        answer = "";
+                        break;
+                    }
+                    try {
+                        Thread.sleep(10);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+            });
+            messageScheduler.start();
+        }
+    }
 }

--- a/src/main/java/ml/denisd3d/minecraft2discord/events/DiscordEvents.java
+++ b/src/main/java/ml/denisd3d/minecraft2discord/events/DiscordEvents.java
@@ -96,8 +96,6 @@ public class DiscordEvents extends ListenerAdapter
                                 return; // We have processed the message. If missingPermissionsMessage is empty process like a chat message
                             }
                         }
-                        MessageManager.sendQuotesMessage(event.getTextChannel(), DiscordCommandSource.answer);
-                        DiscordCommandSource.answer = "";
                         return; // We have processed the message
                     }
 


### PR DESCRIPTION
This batches messages for the command sender for 100ms before sending them instead of only sending them if we receive a command. 

If we get a new message during the 100ms we refresh the timer. 